### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # We use pnpm for package management.
+  - package-ecosystem: 'npm'
+    # We only have a package.json in the root.
+    directory: '/'
+    # Check weekly to prevent too many PRs.
+    schedule:
+      interval: 'weekly'
+    allow:
+      # Starting slow by only checking our own packages for updates.
+      - dependency-name: '@metaplex-foundation/*'


### PR DESCRIPTION
Enable automated updates for Metaplex dependencies

This PR adds Dependabot configuration to enable automated weekly updates for @metaplex-foundation/* dependencies.

The configuration will:
- Check for updates weekly on Mondays
- Create PRs for outdated Metaplex dependencies
- Help keep dependencies up-to-date with minimal manual intervention